### PR TITLE
wscript: fix repeatedly appending all the js files

### DIFF
--- a/wscript
+++ b/wscript
@@ -34,7 +34,7 @@ def build(ctx):
     ctx.path.make_node('src/js/').mkdir()
     js_paths = [node.abspath() for node in ctx.path.ant_glob("src/*.js")]
     if js_paths:
-        ctx.exec_command(['cat'] + js_paths, stdout=open('src/js/pebble-js-app.js', 'a'))
+        ctx.exec_command(['cat'] + js_paths, stdout=open('src/js/pebble-js-app.js', 'w'))
 
     ctx.load('pebble_sdk')
 


### PR DESCRIPTION
Changes the open mode on src/js/pebble-js-app.js to write instead of
append, to prevent multiple copies of the source JS files from
populating the destination file.
