### PR TITLE
location.js: provide an error handler

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -13,6 +13,8 @@ Pebble.addEventListener('ready', function() {
         POS_LAT: cleanCoordinate(pos.coords.latitude)
       });
       console.log("Sent coordinates (" + pos.coords.longitude + ", " + pos.coords.latitude + ")");
+    }, function error(err) {
+      console.log('ERROR(' + err.code + '): ' + err.message);
     }, {
       timeout: 10000,
       maximumAge: 600000


### PR DESCRIPTION
Provide an error handler for the geolocation API, otherwise on at least
some devices it won't work at all.
