### PR TITLE
stop_list.c: avoid integer overflows

### DIFF
--- a/src/stop_list.c
+++ b/src/stop_list.c
@@ -56,7 +56,7 @@ void select_list_select_stop(uint8_t stop_id, bool show_window) {
 static uint32_t prv_dist_sq(int32_t lon1, int32_t lat1, int32_t lon2, int32_t lat2) {
   int32_t lon_diff = lon1 - lon2;
   int32_t lat_diff = lat1 - lat2;
-  return lon_diff * lon_diff + lat_diff * lat_diff;
+  return abs(lon_diff) + abs(lat_diff);
 }
 
 void show_nearest_stop(int32_t lon, int32_t lat) {


### PR DESCRIPTION
The previous method resulted in integer overflows for nearly all
stations, and so the "closest" station after overflow wraparound could
end up being one really far away, even if you're standing at a station.
This method mostly preserves the spirit of the previous method, while
avoiding integer overflows.  The algorithm prefers a shorter leg sum
over actual shortest distance, so it can result in ordering a station
that is slightly farther away before a station that is slightly closer.
However, as the common case is that you're standing at the station, or
are otherwise nearby, the end result will end up matching the spirit of
the previous method.

I didn't change the name of the function, because I wanted the actual change to be as minimal as possible, and I couldn't think of a suitable name anyway.
