### PR TITLE
train_times_list.c: fix a selection bug

### DIFF
--- a/src/train_times_list.c
+++ b/src/train_times_list.c
@@ -93,8 +93,10 @@ static uint16_t prv_get_menu_rows(struct MenuLayer *menu_layer, uint16_t section
 }
 
 static void prv_handle_menu_click(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *context) {
-  const TrainTime *time = &s_times[cell_index->row];
-  show_trip_stop_list(time->trip, time->sequence);
+  if(cell_index->row < s_time_count) {
+    const TrainTime *time = &s_times[cell_index->row];
+    show_trip_stop_list(time->trip, time->sequence);
+  }
 }
 
 static int16_t prv_get_cell_height(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *callback_context) {


### PR DESCRIPTION
The currently selected row can be greated than the stop time count, as
is the case when there are no future stops in the current day, so check
that the selected row is less than that, otherwise just ignore the
click.
